### PR TITLE
Update deconvolution-inl.h. Change the condition control statement in InferPad. Merge differences between v0.8 and v0.9.

### DIFF
--- a/src/operator/deconvolution-inl.h
+++ b/src/operator/deconvolution-inl.h
@@ -88,7 +88,22 @@ struct DeconvolutionParam : public dmlc::Parameter<DeconvolutionParam> {
 
   template<size_t ndim>
   void InferPad(TShape input, index_t (&o_pad)[ndim], index_t (&o_adj)[ndim] ) const {
-    if (target_shape.ndim() != 0) {
+    
+    // Modified by Li.bs
+    // Use tag to control the calculation of pad 
+    bool bCal = false;
+      if (target_shape.ndim() != 0)
+      {
+          for (int i = 0; i < target_shape.ndim(); i++)
+          {
+              if (target_shape[i] != 0)
+              {
+                  bCal = true;
+              }
+          }
+      }
+ 
+      if (bCal) {
       size_t input_ndim = input.ndim();
 
       for (unsigned int i = 0; i < ndim; i++) {


### PR DESCRIPTION
There seems to be a bug at the condition control statement in InferPad. Original version(v0.9) only use target_shape.ndim to decide the calculation of pad. But we find even the target_shape.ndim is not zero, values of target_shape can be zero. When we load v0.8 model with v0.9, this may cause error calculation of pad.